### PR TITLE
Mac and linux

### DIFF
--- a/.profile-prompt
+++ b/.profile-prompt
@@ -1,77 +1,67 @@
 #!/bin/bash
-# Check for shell type
-if [ -z "$BASH_VERSION" ] && [ -z "$ZSH_VERSION" ]; then
-    exit 0
-fi
-
 # If not running interactively, don't do anything
 case $- in
     *i*) ;;
       *) return;;
 esac
 
-#-------------------------------------------------------------
+if [ -n "$BASH_VERSION" ];
+then
+    # Color definitions (taken from Color Bash Prompt HowTo).
+    # Some colors might look different of some terminals.
+    # For example, I see 'Bold Red' as 'orange' on my screen,
+    # hence the 'Green' 'BRed' 'Red' sequence I often use in my prompt.
 
-# Adjust escape sequences for Zsh compatibility
-if [ -n "$ZSH_VERSION" ]; then
-    autoload -U colors && colors
-    setopt PROMPT_SUBST
-    ESCAPE_START="%{"
-    ESCAPE_END="%}"
+    # Normal Colors
+    Black='\e[0;30m'        # Black
+    Red='\e[0;31m'          # Red
+    Green='\e[0;32m'        # Green
+    Yellow='\e[0;33m'       # Yellow
+    Blue='\e[0;34m'         # Blue
+    Purple='\e[0;35m'       # Purple
+    Cyan='\e[0;36m'         # Cyan
+    White='\e[0;37m'        # White
+
+    # Bold
+    BBlack='\e[1;30m'       # Black
+    BRed='\e[1;31m'         # Red
+    BGreen='\e[1;32m'       # Green
+    BYellow='\e[1;33m'      # Yellow
+    BBlue='\e[1;34m'        # Blue
+    BPurple='\e[1;35m'      # Purple
+    BCyan='\e[1;36m'        # Cyan
+    BWhite='\e[1;37m'       # White
+
+    # Background
+    On_Black='\e[40m'       # Black
+    On_Red='\e[41m'         # Red
+    On_Green='\e[42m'       # Green
+    On_Yellow='\e[43m'      # Yellow
+    On_Blue='\e[44m'        # Blue
+    On_Purple='\e[45m'      # Purple
+    On_Cyan='\e[46m'        # Cyan
+    On_White='\e[47m'       # White
+
+    NC="\e[m"               # Color Reset
+
+    if [[ ${USER} == "root" ]]; then
+        SU=${Red}           # User is root.
+        PROMPT='#'
+    elif [[ ${USER} != $(logname) ]]; then
+        SU=${BBlue}          # User is not login user.
+        PROMPT='\$'
+    else
+        SU=${BGreen}         # User is normal (well ... most of us are).
+        PROMPT='\$'
+    fi
+
+    PS1="\[\e]2;\u@\H \w\a${SU}\]\#${PROMPT} "
+
+    # Export and terminate with no color
+    export PS1="${PS1}\[${NC}\]"
+elif [ -n "$ZSH_VERSION" ]; then
+    # Nothing to do for zsh
 else
-    ESCAPE_START="\["
-    ESCAPE_END="\]"
+    # Unknown shell
+    exit 0
 fi
-
-# Color definitions
-Black="${ESCAPE_START}\e[0;30m${ESCAPE_END}"        # Black
-Red="${ESCAPE_START}\e[0;31m${ESCAPE_END}"          # Red
-Green="${ESCAPE_START}\e[0;32m${ESCAPE_END}"        # Green
-Yellow="${ESCAPE_START}\e[0;33m${ESCAPE_END}"       # Yellow
-Blue="${ESCAPE_START}\e[0;34m${ESCAPE_END}"         # Blue
-Purple="${ESCAPE_START}\e[0;35m${ESCAPE_END}"       # Purple
-Cyan="${ESCAPE_START}\e[0;36m${ESCAPE_END}"         # Cyan
-White="${ESCAPE_START}\e[0;37m${ESCAPE_END}"        # White
-
-# Bold
-BBlack="${ESCAPE_START}\e[1;30m${ESCAPE_END}"       # Black
-BRed="${ESCAPE_START}\e[1;31m${ESCAPE_END}"         # Red
-BGreen="${ESCAPE_START}\e[1;32m${ESCAPE_END}"       # Green
-BYellow="${ESCAPE_START}\e[1;33m${ESCAPE_END}"      # Yellow
-BBlue="${ESCAPE_START}\e[1;34m${ESCAPE_END}"        # Blue
-BPurple="${ESCAPE_START}\e[1;35m${ESCAPE_END}"      # Purple
-BCyan="${ESCAPE_START}\e[1;36m${ESCAPE_END}"        # Cyan
-BWhite="${ESCAPE_START}\e[1;37m${ESCAPE_END}"       # White
-
-# Background
-On_Black="${ESCAPE_START}\e[40m${ESCAPE_END}"       # Black
-On_Red="${ESCAPE_START}\e[41m${ESCAPE_END}"         # Red
-On_Green="${ESCAPE_START}\e[42m${ESCAPE_END}"       # Green
-On_Yellow="${ESCAPE_START}\e[43m${ESCAPE_END}"      # Yellow
-On_Blue="${ESCAPE_START}\e[44m${ESCAPE_END}"        # Blue
-On_Purple="${ESCAPE_START}\e[45m${ESCAPE_END}"      # Purple
-On_Cyan="${ESCAPE_START}\e[46m${ESCAPE_END}"        # Cyan
-On_White="${ESCAPE_START}\e[47m${ESCAPE_END}"       # White
-NC="${ESCAPE_START}\e[m${ESCAPE_END}"               # Color Reset
-
-# Determine user type for prompt color
-if [[ ${USER} == "root" ]]; then
-    SU=${Red}           # User is root.
-    PROMPT='#'
-elif [[ ${USER} != $(logname) ]]; then
-    SU=${BBlue}         # User is not login user.
-    PROMPT='\$'
-else
-    SU=${BGreen}        # User is normal (well ... most of us are).
-    PROMPT='\$'
-fi
-
-# Set prompt
-if [ -n "$ZSH_VERSION" ]; then
-    PS1="%{${SU}%}%#${PROMPT} "
-else
-    PS1="${ESCAPE_START}${SU}${ESCAPE_END}\#${PROMPT} "
-fi
-
-# Export and terminate with no color
-export PS1="${PS1}${NC}"

--- a/.profile-prompt
+++ b/.profile-prompt
@@ -1,62 +1,77 @@
 #!/bin/bash
-if [ -z "$BASH_VERSION" ] || [ -n "$WORKSPACES" ]; then
+# Check for shell type
+if [ -z "$BASH_VERSION" ] && [ -z "$ZSH_VERSION" ]; then
     exit 0
 fi
 
 # If not running interactively, don't do anything
-[ -z "$PS1" ] && return
+case $- in
+    *i*) ;;
+      *) return;;
+esac
 
 #-------------------------------------------------------------
 
-# Color definitions (taken from Color Bash Prompt HowTo).
-# Some colors might look different of some terminals.
-# For example, I see 'Bold Red' as 'orange' on my screen,
-# hence the 'Green' 'BRed' 'Red' sequence I often use in my prompt.
+# Adjust escape sequences for Zsh compatibility
+if [ -n "$ZSH_VERSION" ]; then
+    autoload -U colors && colors
+    setopt PROMPT_SUBST
+    ESCAPE_START="%{"
+    ESCAPE_END="%}"
+else
+    ESCAPE_START="\["
+    ESCAPE_END="\]"
+fi
 
-# Normal Colors
-Black='\e[0;30m'        # Black
-Red='\e[0;31m'          # Red
-Green='\e[0;32m'        # Green
-Yellow='\e[0;33m'       # Yellow
-Blue='\e[0;34m'         # Blue
-Purple='\e[0;35m'       # Purple
-Cyan='\e[0;36m'         # Cyan
-White='\e[0;37m'        # White
+# Color definitions
+Black="${ESCAPE_START}\e[0;30m${ESCAPE_END}"        # Black
+Red="${ESCAPE_START}\e[0;31m${ESCAPE_END}"          # Red
+Green="${ESCAPE_START}\e[0;32m${ESCAPE_END}"        # Green
+Yellow="${ESCAPE_START}\e[0;33m${ESCAPE_END}"       # Yellow
+Blue="${ESCAPE_START}\e[0;34m${ESCAPE_END}"         # Blue
+Purple="${ESCAPE_START}\e[0;35m${ESCAPE_END}"       # Purple
+Cyan="${ESCAPE_START}\e[0;36m${ESCAPE_END}"         # Cyan
+White="${ESCAPE_START}\e[0;37m${ESCAPE_END}"        # White
 
 # Bold
-BBlack='\e[1;30m'       # Black
-BRed='\e[1;31m'         # Red
-BGreen='\e[1;32m'       # Green
-BYellow='\e[1;33m'      # Yellow
-BBlue='\e[1;34m'        # Blue
-BPurple='\e[1;35m'      # Purple
-BCyan='\e[1;36m'        # Cyan
-BWhite='\e[1;37m'       # White
+BBlack="${ESCAPE_START}\e[1;30m${ESCAPE_END}"       # Black
+BRed="${ESCAPE_START}\e[1;31m${ESCAPE_END}"         # Red
+BGreen="${ESCAPE_START}\e[1;32m${ESCAPE_END}"       # Green
+BYellow="${ESCAPE_START}\e[1;33m${ESCAPE_END}"      # Yellow
+BBlue="${ESCAPE_START}\e[1;34m${ESCAPE_END}"        # Blue
+BPurple="${ESCAPE_START}\e[1;35m${ESCAPE_END}"      # Purple
+BCyan="${ESCAPE_START}\e[1;36m${ESCAPE_END}"        # Cyan
+BWhite="${ESCAPE_START}\e[1;37m${ESCAPE_END}"       # White
 
 # Background
-On_Black='\e[40m'       # Black
-On_Red='\e[41m'         # Red
-On_Green='\e[42m'       # Green
-On_Yellow='\e[43m'      # Yellow
-On_Blue='\e[44m'        # Blue
-On_Purple='\e[45m'      # Purple
-On_Cyan='\e[46m'        # Cyan
-On_White='\e[47m'       # White
+On_Black="${ESCAPE_START}\e[40m${ESCAPE_END}"       # Black
+On_Red="${ESCAPE_START}\e[41m${ESCAPE_END}"         # Red
+On_Green="${ESCAPE_START}\e[42m${ESCAPE_END}"       # Green
+On_Yellow="${ESCAPE_START}\e[43m${ESCAPE_END}"      # Yellow
+On_Blue="${ESCAPE_START}\e[44m${ESCAPE_END}"        # Blue
+On_Purple="${ESCAPE_START}\e[45m${ESCAPE_END}"      # Purple
+On_Cyan="${ESCAPE_START}\e[46m${ESCAPE_END}"        # Cyan
+On_White="${ESCAPE_START}\e[47m${ESCAPE_END}"       # White
+NC="${ESCAPE_START}\e[m${ESCAPE_END}"               # Color Reset
 
-NC="\e[m"               # Color Reset
-
+# Determine user type for prompt color
 if [[ ${USER} == "root" ]]; then
     SU=${Red}           # User is root.
     PROMPT='#'
 elif [[ ${USER} != $(logname) ]]; then
-    SU=${BBlue}          # User is not login user.
+    SU=${BBlue}         # User is not login user.
     PROMPT='\$'
 else
-    SU=${BGreen}         # User is normal (well ... most of us are).
+    SU=${BGreen}        # User is normal (well ... most of us are).
     PROMPT='\$'
 fi
 
-PS1="\[\e]2;\u@\H \w\a${SU}\]\#${PROMPT} "
+# Set prompt
+if [ -n "$ZSH_VERSION" ]; then
+    PS1="%{${SU}%}%#${PROMPT} "
+else
+    PS1="${ESCAPE_START}${SU}${ESCAPE_END}\#${PROMPT} "
+fi
 
 # Export and terminate with no color
-export PS1="${PS1}\[${NC}\]"
+export PS1="${PS1}${NC}"


### PR DESCRIPTION
Shell detection improvements:
* [`.profile-prompt`](diffhunk://#diff-2ce89b20adebff1736e1eb0f26332eb63ebaebb26d3620e61fc3dcdde55b805eR62-R67): Added specific checks to work for both Bash and Zsh shells. If the shell is not Bash or Zsh, the script will exit.