### PR TITLE
Add Cygwin conditional check to .profile-cygwin

### DIFF
--- a/~/.profile-cygwin
+++ b/~/.profile-cygwin
@@ -1,0 +1,7 @@
+if [[ "$(uname -s)" == *CYGWIN* ]]; then
+    # settings typically used for cygwin
+    appendPath /cygdrive/c/Program\ Files/Docker/Docker/resources/bin/
+    appendPath /cygdrive/c/Program\ Files/Amazon\ Corretto/*/bin
+    appendPath /cygdrive/c/Program\ Files/PuTTY
+    appendPath /cygdrive/c/WINDOWS/System32/OpenSSH
+fi


### PR DESCRIPTION
Adds conditional checks to `.profile-cygwin` to ensure it only executes in a Cygwin environment.
- **Conditional Execution**: Implements a check at the beginning of `.profile-cygwin` using `if [[ "$(uname -s)" == *CYGWIN* ]]; then`, ensuring the script runs only under Cygwin.
- **Path Extensions**: Adds commands within the conditional block to append specific directories to the PATH variable, targeting Docker, Amazon Corretto, PuTTY, and Windows System32 OpenSSH paths.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrishodson/dotfiles?shareId=cd730235-1568-4474-880e-8b9a6ed7c897).